### PR TITLE
Include operation name in usage.

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -86,8 +86,13 @@ options_parse(int argc, char **argv, options_t *const opts)
 void
 options_usage(int exit_code)
 {
-    printf("Usage: %s backup|restore [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE "
+    printf("Usage: %s backup [-s SECTOR_SIZE] [-b BUFFER_SIZE] INFILE REFFILE "
            "OUTFILE\n",
+           PROGRAM_NAME_STR);
+    printf("   Or: %s restore [-s SECTOR_SIZE] [-b BUFFER_SIZE] REFFILE "
+           "OUTFILE\n",
+           PROGRAM_NAME_STR);
+    printf("   Or: %s help\n",
            PROGRAM_NAME_STR);
     exit(exit_code);
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -86,7 +86,7 @@ options_parse(int argc, char **argv, options_t *const opts)
 void
 options_usage(int exit_code)
 {
-    printf("Usage: %s [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE "
+    printf("Usage: %s backup|restore [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE "
            "OUTFILE\n",
            PROGRAM_NAME_STR);
     exit(exit_code);


### PR DESCRIPTION
Hi, just a small improvement, this caused me a bit of confusion. Here is my terminal history the first time I used `diff-dd`:

```bash
$ src/diff-dd 
Usage: diff-dd [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE OUTFILE

$ src/diff-dd -s 4096 /home/btimby/part-v1.0.8B.img /home/btimby/part-v1.0.8A.img foo.img
Usage: diff-dd [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE OUTFILE

$ src/diff-dd /home/btimby/part-v1.0.8B.img /home/btimby/part-v1.0.8A.img foo.img
Usage: diff-dd [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE OUTFILE

$ src/diff-dd /home/btimby/part-v1.0.8B.img /home/btimby/part-v1.0.8A.img ./foo.img
Usage: diff-dd [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE OUTFILE

$ src/diff-dd /home/btimby/part-v1.0.8B.img /home/btimby/part-v1.0.8A.img /home/btimby/diff.img
Usage: diff-dd [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE OUTFILE

$ src/diff-dd /home/btimby/part-v1.0.8A.img /home/btimby/diff.img
Usage: diff-dd [-s SECTOR_SIZE] [-b BUFFER_SIZE] [INFILE] REFFILE OUTFILE
```

As you can see, the usage does not indicate that an operation (backup or restore) is required. The documentation made this clear, but IMO the usage text should also include this detail.